### PR TITLE
feat: add transaction update and delete endpoints

### DIFF
--- a/src/main/java/org/example/finlog/DTO/TransactionRequest.java
+++ b/src/main/java/org/example/finlog/DTO/TransactionRequest.java
@@ -1,6 +1,5 @@
 package org.example.finlog.DTO;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +9,7 @@ import lombok.Setter;
 import org.example.finlog.enums.Category;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -17,12 +17,12 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TransactionRequest {
-    @NotNull
+    private UUID id;
+
     private BigDecimal amount;
 
     @Size(max = 150)
     private String description;
 
-    @NotNull
     private Category category;
 }

--- a/src/main/java/org/example/finlog/controller/TransactionController.java
+++ b/src/main/java/org/example/finlog/controller/TransactionController.java
@@ -59,7 +59,7 @@ public class TransactionController {
         }
     }
 
-    @PostMapping("/create")
+    @PostMapping
     public ResponseEntity<HttpStatus> create(
             @Valid @RequestBody TransactionRequest request,
             Principal principal
@@ -76,7 +76,7 @@ public class TransactionController {
         }
     }
 
-    @DeleteMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<HttpStatus> delete(@PathVariable UUID id) {
         try {
             transactionService.delete(id);

--- a/src/main/java/org/example/finlog/controller/TransactionController.java
+++ b/src/main/java/org/example/finlog/controller/TransactionController.java
@@ -1,5 +1,6 @@
 package org.example.finlog.controller;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.example.finlog.DTO.TransactionRequest;
@@ -9,11 +10,13 @@ import org.example.finlog.service.TransactionService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -76,15 +79,41 @@ public class TransactionController {
         }
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<HttpStatus> delete(@PathVariable UUID id) {
+    @PutMapping
+    public ResponseEntity<HttpStatus> update(
+            @Valid @RequestBody TransactionRequest request,
+            Principal principal
+    ) {
         try {
-            transactionService.delete(id);
+            String username = principal.getName();
+            transactionService.update(username, request);
             return ResponseEntity.ok().build();
+        } catch (UsernameNotFoundException | EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         } catch (Exception e) {
-            log.error("Error deleting transaction, ", e);
+            log.error("Error updating transaction", e);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<HttpStatus> delete(
+            @PathVariable UUID id,
+            Principal principal
+    ) {
+        try {
+            String username = principal.getName();
+            transactionService.delete(username, id);
+            return ResponseEntity.ok().build();
+        } catch (UsernameNotFoundException | EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (Exception e) {
+            log.error("Error updating transaction", e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+    }
 }

--- a/src/main/java/org/example/finlog/controller/TransactionController.java
+++ b/src/main/java/org/example/finlog/controller/TransactionController.java
@@ -10,7 +10,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -71,7 +74,17 @@ public class TransactionController {
             log.error("Error saving transaction", e);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
+    }
 
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<HttpStatus> delete(@PathVariable UUID id) {
+        try {
+            transactionService.delete(id);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            log.error("Error deleting transaction, ", e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
     }
 
 }

--- a/src/main/java/org/example/finlog/repository/TransactionRepository.java
+++ b/src/main/java/org/example/finlog/repository/TransactionRepository.java
@@ -2,6 +2,7 @@ package org.example.finlog.repository;
 
 import org.example.finlog.entity.Transaction;
 import org.example.finlog.enums.Category;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -66,10 +67,35 @@ public class TransactionRepository {
         );
     }
 
+    @Transactional
     public void delete(UUID id) {
         jdbcTemplate.update(
                 "delete from transaction_ where id = ?",
                 id
         );
+    }
+
+    @Transactional
+    public void update(Transaction transaction) {
+        jdbcTemplate.update(
+                "update transaction_ set amount = ?, description = ?, category = ? where id = ?",
+                transaction.getAmount(),
+                transaction.getDescription(),
+                transaction.getCategory().toString(),
+                transaction.getId()
+        );
+    }
+
+    @Transactional
+    public Transaction getById(UUID id) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "select * from transaction_ where id = ?",
+                    new BeanPropertyRowMapper<>(Transaction.class),
+                    id
+            );
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/example/finlog/repository/TransactionRepository.java
+++ b/src/main/java/org/example/finlog/repository/TransactionRepository.java
@@ -65,4 +65,11 @@ public class TransactionRepository {
                 transaction.getTransactionDate()
         );
     }
+
+    public void delete(UUID id) {
+        jdbcTemplate.update(
+                "delete from transaction_ where id = ?",
+                id
+        );
+    }
 }

--- a/src/main/java/org/example/finlog/service/TransactionService.java
+++ b/src/main/java/org/example/finlog/service/TransactionService.java
@@ -61,4 +61,8 @@ public class TransactionService {
                 .category(request.getCategory())
                 .build();
     }
+
+    public void delete(UUID id) {
+        transactionRepository.delete(id);
+    }
 }

--- a/src/main/resources/db/migration/V4__Alter_amount.sql
+++ b/src/main/resources/db/migration/V4__Alter_amount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transaction_
+    ALTER COLUMN amount TYPE DECIMAL(10, 2);

--- a/src/test/java/org/example/finlog/integration/repository/UserRepositoryTest.java
+++ b/src/test/java/org/example/finlog/integration/repository/UserRepositoryTest.java
@@ -32,7 +32,7 @@ class UserRepositoryTest {
     }
 
     @Test
-    void shouldSaveAndRetrieveUserByEmail() {
+    void getUserByEmail_shouldSaveAndRetrieveUserByEmail() {
         userRepository.save(user);
 
         User retrieved = userRepository.getUserByEmail(user.getEmail());
@@ -51,7 +51,7 @@ class UserRepositoryTest {
     }
 
     @Test
-    void shouldGetRegistrationDateById() {
+    void getRegistrationDate_shouldGetRegistrationDateById() {
         userRepository.save(user);
 
         LocalDate date = userRepository.getRegistrationDate(user.getId());

--- a/src/test/java/org/example/finlog/unit/service/TransactionServiceTest.java
+++ b/src/test/java/org/example/finlog/unit/service/TransactionServiceTest.java
@@ -1,6 +1,7 @@
 package org.example.finlog.unit.service;
 
 
+import jakarta.persistence.EntityNotFoundException;
 import org.example.finlog.DTO.TransactionRequest;
 import org.example.finlog.entity.Transaction;
 import org.example.finlog.entity.User;
@@ -8,6 +9,7 @@ import org.example.finlog.enums.Category;
 import org.example.finlog.repository.TransactionRepository;
 import org.example.finlog.service.TransactionService;
 import org.example.finlog.service.UserService;
+import org.example.finlog.util.TransactionDataFactory;
 import org.example.finlog.util.UserDataFactory;
 import org.example.finlog.util.UuidGenerator;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.math.BigDecimal;
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +32,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,22 +60,7 @@ class TransactionServiceTest {
     }
 
     @Test
-    void getFilteredData_withoutCategory_returnsAllFiltered() {
-        LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2026, 1, 1, 0, 0);
-
-        List<Transaction> expected = List.of(new Transaction());
-        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(userService.getRegistrationDate(user.getId())).thenReturn(start.toLocalDate());
-        when(transactionRepository.getFiltered(start, end)).thenReturn(expected);
-
-        List<Transaction> result = transactionService.getFilteredData(user.getEmail(), null, start, end);
-
-        assertThat(result).isEqualTo(expected);
-    }
-
-    @Test
-    void getFilteredData_withCategory_returnsFilteredByCategory() {
+    void getFilteredData_shouldReturnFiltered() {
         LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0);
         LocalDateTime end = LocalDateTime.of(2026, 1, 1, 0, 0);
         Category category = Category.FAST_FOOD;
@@ -86,7 +76,22 @@ class TransactionServiceTest {
     }
 
     @Test
-    void getFilteredData_withNullDates_usesDefaults() {
+    void getFilteredData_shouldReturnFilteredWhenCategoryIsNull() {
+        LocalDateTime start = LocalDateTime.of(2025, 1, 1, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2026, 1, 1, 0, 0);
+
+        List<Transaction> expected = List.of(new Transaction());
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(userService.getRegistrationDate(user.getId())).thenReturn(start.toLocalDate());
+        when(transactionRepository.getFiltered(start, end)).thenReturn(expected);
+
+        List<Transaction> result = transactionService.getFilteredData(user.getEmail(), null, start, end);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void getFilteredData_shouldUseDefaultValuesWhenDateIsNull() {
         LocalDateTime regDate = LocalDateTime.of(2025, 1, 1, 0, 0);
 
         when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
@@ -99,7 +104,17 @@ class TransactionServiceTest {
     }
 
     @Test
-    void save_createsAndSavesTransaction() {
+    void getFilteredData_shouldThrowsWhenUserNotFound() {
+        when(userService.getUserByEmail("nope@example.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                transactionService.getFilteredData("nope@example.com", null, null, null)
+        ).isInstanceOf(UsernameNotFoundException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void save_shouldCreateAndSaveTransactionCorrectly() {
         UUID txId = UUID.randomUUID();
         when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(uuidGenerator.generate()).thenReturn(txId);
@@ -123,12 +138,188 @@ class TransactionServiceTest {
     }
 
     @Test
-    void getFilteredData_userNotFound_throws() {
-        when(userService.getUserByEmail("nope@example.com")).thenReturn(Optional.empty());
+    void update_shouldUpdateTransaction() throws AccessDeniedException {
+        UUID txId = UUID.randomUUID();
+
+        Transaction existing = Transaction.builder()
+                .id(txId)
+                .user(user)
+                .amount(BigDecimal.valueOf(100))
+                .description("old desc")
+                .category(Category.OTHER)
+                .build();
+
+
+        BigDecimal expectedAmount = BigDecimal.valueOf(200);
+        String expectedDescription = "new desc";
+        Category expectedCategory = Category.FAST_FOOD;
+
+        TransactionRequest request = TransactionRequest.builder()
+                .id(txId)
+                .amount(expectedAmount)
+                .description(expectedDescription)
+                .category(expectedCategory)
+                .build();
+
+
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(transactionRepository.getById(txId)).thenReturn(existing);
+
+        transactionService.update(user.getEmail(), request);
+
+        verify(transactionRepository).getById(txId);
+
+        verify(transactionRepository).update(argThat(tx ->
+                tx.getId().equals(txId) &&
+                        tx.getUser().equals(user) &&
+                        tx.getAmount().equals(expectedAmount) &&
+                        tx.getDescription().equals(expectedDescription) &&
+                        tx.getCategory().equals(expectedCategory)
+        ));
+
+        verify(transactionRepository, never()).delete(any());
+        verify(transactionRepository, never()).save(any(), any());
+    }
+
+    @Test
+    void update_shouldThrowsWhenUserNotOwner() {
+        UUID txId = UUID.randomUUID();
+
+        User attacker = User.builder()
+                .id(UUID.randomUUID())
+                .email("attacker@example.com")
+                .name("attacker")
+                .passwordHash("pass")
+                .build();
+
+
+        Transaction existing = Transaction.builder()
+                .id(txId)
+                .user(user)
+                .amount(BigDecimal.valueOf(100))
+                .description("old desc")
+                .category(Category.OTHER)
+                .build();
+
+        TransactionRequest request = TransactionRequest.builder()
+                .id(txId)
+                .amount(BigDecimal.valueOf(200))
+                .description("new desc")
+                .category(Category.FAST_FOOD)
+                .build();
+
+
+        when(userService.getUserByEmail(attacker.getEmail())).thenReturn(Optional.of(attacker));
+        when(transactionRepository.getById(txId)).thenReturn(existing);
 
         assertThatThrownBy(() ->
-                transactionService.getFilteredData("nope@example.com", null, null, null)
+                transactionService.update(attacker.getEmail(), request)
+        ).isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Access denied");
+
+        verify(transactionRepository, never()).update(any());
+    }
+
+    @Test
+    void update_shouldThrowsWhenTransactionNotFound() {
+        UUID txId = UUID.randomUUID();
+        TransactionRequest request = TransactionDataFactory.sampleTransactionRequest(txId);
+
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        doReturn(null).when(transactionRepository).getById(txId);
+
+        assertThatThrownBy(() ->
+                transactionService.update(user.getEmail(), request)
+        ).isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Transaction not found");
+
+        verify(transactionRepository, never()).update(any());
+    }
+
+    @Test
+    void update_shouldThrowsWhenUserNotFound() {
+        UUID txId = UUID.randomUUID();
+        TransactionRequest request = TransactionDataFactory.sampleTransactionRequest(txId);
+
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                transactionService.update(user.getEmail(), request)
         ).isInstanceOf(UsernameNotFoundException.class)
-                .hasMessageContaining("User not found");
+                .hasMessageContaining("User not found: " + user.getEmail());
+    }
+
+    @Test
+    void delete_shouldDeleteTransactionCorrectly() throws AccessDeniedException {
+        UUID txId = UUID.randomUUID();
+        Transaction transaction = TransactionDataFactory.sampleTransaction(txId, user);
+
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(transactionRepository.getById(txId)).thenReturn(transaction);
+
+        transactionService.delete(user.getEmail(), txId);
+
+        verify(transactionRepository).delete(eq(txId));
+
+        verify(transactionRepository, never()).update(any());
+        verify(transactionRepository, never()).save(any(), any());
+    }
+
+    @Test
+    void delete_shouldThrowsWhenUserNotOwner() {
+        UUID txId = UUID.randomUUID();
+
+        User attacker = User.builder()
+                .id(UUID.randomUUID())
+                .email("attacker@example.com")
+                .name("attacker")
+                .passwordHash("pass")
+                .build();
+
+
+        Transaction transaction = Transaction.builder()
+                .id(txId)
+                .user(user)
+                .amount(BigDecimal.valueOf(100))
+                .description("old desc")
+                .category(Category.OTHER)
+                .build();
+
+
+        when(userService.getUserByEmail(attacker.getEmail())).thenReturn(Optional.of(attacker));
+        when(transactionRepository.getById(txId)).thenReturn(transaction);
+
+        assertThatThrownBy(() ->
+                transactionService.delete(attacker.getEmail(), txId)
+        ).isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Access denied");
+
+        verify(transactionRepository, never()).delete(any());
+    }
+
+
+    @Test
+    void delete_shouldThrowsWhenTransactionNotFound() {
+        UUID txId = UUID.randomUUID();
+
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        doReturn(null).when(transactionRepository).getById(txId);
+
+        assertThatThrownBy(() ->
+                transactionService.delete(user.getEmail(), txId)
+        ).isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Transaction not found");
+    }
+
+    @Test
+    void delete_shouldThrowsWhenUserNotFound() {
+        UUID txId = UUID.randomUUID();
+
+        when(userService.getUserByEmail(user.getEmail())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                transactionService.delete(user.getEmail(), txId)
+        ).isInstanceOf(UsernameNotFoundException.class)
+                .hasMessageContaining("User not found: " + user.getEmail());
     }
 }

--- a/src/test/java/org/example/finlog/util/TransactionDataFactory.java
+++ b/src/test/java/org/example/finlog/util/TransactionDataFactory.java
@@ -11,8 +11,9 @@ import java.util.UUID;
 
 public class TransactionDataFactory {
 
-    public static TransactionRequest sampleTransactionRequest() {
+    public static TransactionRequest sampleTransactionRequest(UUID id) {
         return TransactionRequest.builder()
+                .id(id)
                 .amount(new BigDecimal("123.45"))
                 .description("Test description")
                 .category(Category.OTHER)


### PR DESCRIPTION
## Changes Introduced
Added full CRUD support for transactions with:
- `PUT /transactions/{id}` - Update existing transaction
- `DELETE /transactions/{id}` - Remove transaction

## Key Implementations

1. Backend layer: 
    - New REST endpoints
    - Business logic for update/delete operations
    - Database update/delete operations
2. Database changes:
    - Modified `amount` column to `Decimal(10, 2)` in `V4__Alter_amount.sql`
3. Testing:
    - Added test covering:
        - Successful updats/deletes
        - Non-existen transaction handling
    - Refactored tests names to `method_shouldExpectedBehavior`
    