### PR TITLE
refactor: centralize error handling to global advice

### DIFF
--- a/src/main/java/org/example/finlog/DTO/ErrorResponse.java
+++ b/src/main/java/org/example/finlog/DTO/ErrorResponse.java
@@ -1,0 +1,10 @@
+package org.example.finlog.DTO;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final String message;
+}

--- a/src/main/java/org/example/finlog/controller/AuthController.java
+++ b/src/main/java/org/example/finlog/controller/AuthController.java
@@ -24,7 +24,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         log.debug("Login attempt: {}", request.getEmail());
         String token = userService.login(request);
         log.info("User logged: {}", request.getEmail());

--- a/src/main/java/org/example/finlog/controller/AuthController.java
+++ b/src/main/java/org/example/finlog/controller/AuthController.java
@@ -7,7 +7,6 @@ import org.example.finlog.DTO.RegisterRequest;
 import org.example.finlog.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,12 +23,8 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
-        try {
             String token = userService.login(request);
             return ResponseEntity.ok(new AuthResponse(token));
-        } catch (BadCredentialsException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Bad credentials");
-        }
     }
 
     @PostMapping("/register")

--- a/src/main/java/org/example/finlog/controller/AuthController.java
+++ b/src/main/java/org/example/finlog/controller/AuthController.java
@@ -1,6 +1,7 @@
 package org.example.finlog.controller;
 
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 import org.example.finlog.DTO.AuthResponse;
 import org.example.finlog.DTO.LoginRequest;
 import org.example.finlog.DTO.RegisterRequest;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
@@ -23,8 +25,10 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
-            String token = userService.login(request);
-            return ResponseEntity.ok(new AuthResponse(token));
+        log.debug("Login attempt: {}", request.getEmail());
+        String token = userService.login(request);
+        log.info("User logged: {}", request.getEmail());
+        return ResponseEntity.ok(new AuthResponse(token));
     }
 
     @PostMapping("/register")
@@ -34,6 +38,7 @@ public class AuthController {
         }
 
         String token = userService.register(request);
+        log.info("User registered: {}", request.getEmail());
         return ResponseEntity.ok(new AuthResponse(token));
     }
 

--- a/src/main/java/org/example/finlog/controller/TransactionController.java
+++ b/src/main/java/org/example/finlog/controller/TransactionController.java
@@ -7,7 +7,6 @@ import org.example.finlog.entity.Transaction;
 import org.example.finlog.enums.Category;
 import org.example.finlog.service.TransactionService;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -58,7 +57,7 @@ public class TransactionController {
     }
 
     @PostMapping
-    public ResponseEntity<HttpStatus> create(
+    public ResponseEntity<Void> create(
             @Valid @RequestBody TransactionRequest request,
             Principal principal
     ) {
@@ -69,7 +68,7 @@ public class TransactionController {
     }
 
     @PutMapping
-    public ResponseEntity<HttpStatus> update(
+    public ResponseEntity<Void> update(
             @Valid @RequestBody TransactionRequest request,
             Principal principal
     ) throws AccessDeniedException {
@@ -80,7 +79,7 @@ public class TransactionController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<HttpStatus> delete(
+    public ResponseEntity<Void> delete(
             @PathVariable UUID id,
             Principal principal
     ) throws AccessDeniedException {

--- a/src/main/java/org/example/finlog/controller/TransactionController.java
+++ b/src/main/java/org/example/finlog/controller/TransactionController.java
@@ -52,7 +52,8 @@ public class TransactionController {
                         startDate,
                         endDate
                 );
-
+        log.debug("Fetching transactions for user {}, category={}, startDate={}, endDate={}",
+                username, category, startDate, endDate);
         return ResponseEntity.ok(transactions);
     }
 
@@ -63,6 +64,7 @@ public class TransactionController {
     ) {
         String username = principal.getName();
         transactionService.save(username, request);
+        log.debug("Transaction created for user: {}", username);
         return ResponseEntity.ok().build();
     }
 
@@ -73,6 +75,7 @@ public class TransactionController {
     ) throws AccessDeniedException {
         String username = principal.getName();
         transactionService.update(username, request);
+        log.debug("Transaction updated: {}", request.getId());
         return ResponseEntity.ok().build();
     }
 
@@ -83,6 +86,7 @@ public class TransactionController {
     ) throws AccessDeniedException {
         String username = principal.getName();
         transactionService.delete(username, id);
+        log.debug("Transaction deleted: {}", id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/example/finlog/controller/TransactionController.java
+++ b/src/main/java/org/example/finlog/controller/TransactionController.java
@@ -1,6 +1,5 @@
 package org.example.finlog.controller;
 
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.example.finlog.DTO.TransactionRequest;
@@ -10,8 +9,6 @@ import org.example.finlog.service.TransactionService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.nio.file.AccessDeniedException;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,20 +44,16 @@ public class TransactionController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime endDate,
             Principal principal
     ) {
-        try {
-            String username = principal.getName();
-            List<Transaction> transactions = transactionService
-                    .getFilteredData(
-                            username,
-                            category,
-                            startDate,
-                            endDate
-                    );
+        String username = principal.getName();
+        List<Transaction> transactions = transactionService
+                .getFilteredData(
+                        username,
+                        category,
+                        startDate,
+                        endDate
+                );
 
-            return ResponseEntity.ok(transactions);
-        } catch (UsernameNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
+        return ResponseEntity.ok(transactions);
     }
 
     @PostMapping
@@ -67,53 +61,29 @@ public class TransactionController {
             @Valid @RequestBody TransactionRequest request,
             Principal principal
     ) {
-        try {
-            String username = principal.getName();
-            transactionService.save(username, request);
-            return ResponseEntity.ok().build();
-        } catch (UsernameNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        } catch (Exception e) {
-            log.error("Error saving transaction", e);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
+        String username = principal.getName();
+        transactionService.save(username, request);
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping
     public ResponseEntity<HttpStatus> update(
             @Valid @RequestBody TransactionRequest request,
             Principal principal
-    ) {
-        try {
-            String username = principal.getName();
-            transactionService.update(username, request);
-            return ResponseEntity.ok().build();
-        } catch (UsernameNotFoundException | EntityNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        } catch (AccessDeniedException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (Exception e) {
-            log.error("Error updating transaction", e);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
+    ) throws AccessDeniedException {
+        String username = principal.getName();
+        transactionService.update(username, request);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<HttpStatus> delete(
             @PathVariable UUID id,
             Principal principal
-    ) {
-        try {
-            String username = principal.getName();
-            transactionService.delete(username, id);
-            return ResponseEntity.ok().build();
-        } catch (UsernameNotFoundException | EntityNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        } catch (AccessDeniedException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (Exception e) {
-            log.error("Error updating transaction", e);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
+    ) throws AccessDeniedException {
+        String username = principal.getName();
+        transactionService.delete(username, id);
+        return ResponseEntity.noContent().build();
     }
 }
+

--- a/src/main/java/org/example/finlog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/finlog/exception/GlobalExceptionHandler.java
@@ -1,43 +1,82 @@
 package org.example.finlog.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.example.finlog.DTO.ErrorResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnExpectedError(Exception ex) {
+        log.error("Unexpected error", ex);
+        ErrorResponse response = new ErrorResponse("Internal server error");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<String> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
         if (ex.getRequiredType() == LocalDate.class) {
-            String msg = "Invalid value or date format for the parameter " + ex.getName() + ". Expected format: yyyy-MM-dd";
-            return ResponseEntity.badRequest().body(msg);
+            String msg = "Invalid value or date format for the parameter " +
+                    ex.getName() + ". Expected format: yyyy-MM-dd";
+
+            ErrorResponse response = new ErrorResponse(msg);
+            return ResponseEntity.badRequest().body(response);
         }
 
         if (Objects.requireNonNull(ex.getRequiredType()).isEnum()) {
             String allowedValues = Arrays.toString(ex.getRequiredType().getEnumConstants());
-            String msg = "Invalid value for the parameter " + ex.getName() + ". Allowed values: " + allowedValues;
-            return ResponseEntity.badRequest().body(msg);
+            String msg = "Invalid value for the parameter " +
+                    ex.getName() + ". Allowed values: " + allowedValues;
+
+            ErrorResponse response = new ErrorResponse(msg);
+            return ResponseEntity.badRequest().body(response);
         }
 
-        return ResponseEntity.badRequest().body(ex.getMessage());
+        ErrorResponse response = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.badRequest().body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleValidationErrors(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ErrorResponse> handleValidationErrors(MethodArgumentNotValidException ex) {
         String msg = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
                 .map(err -> err.getField() + ": " + err.getDefaultMessage())
                 .collect(Collectors.joining(", "));
 
-        return ResponseEntity.badRequest().body(msg);
+        ErrorResponse response = new ErrorResponse(msg);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+        ErrorResponse response = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+        ErrorResponse response = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleBadCredentials(BadCredentialsException ex) {
+        ErrorResponse response = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.badRequest().body(response);
     }
 }

--- a/src/main/java/org/example/finlog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/finlog/exception/GlobalExceptionHandler.java
@@ -29,6 +29,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        log.debug("Type mismatch for parameter '{}': {}", ex.getName(), ex.getValue());
+
         if (ex.getRequiredType() == LocalDate.class) {
             String msg = "Invalid value or date format for the parameter " +
                     ex.getName() + ". Expected format: yyyy-MM-dd";
@@ -58,18 +60,21 @@ public class GlobalExceptionHandler {
                 .map(err -> err.getField() + ": " + err.getDefaultMessage())
                 .collect(Collectors.joining(", "));
 
+        log.warn("Validation failed: {}", msg);
         ErrorResponse response = new ErrorResponse(msg);
         return ResponseEntity.badRequest().body(response);
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+        log.debug("Not found: {}", ex.getMessage());
         ErrorResponse response = new ErrorResponse(ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+        log.warn("Access denied: {}", ex.getMessage());
         ErrorResponse response = new ErrorResponse(ex.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }

--- a/src/main/java/org/example/finlog/exception/NotFoundException.java
+++ b/src/main/java/org/example/finlog/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package org.example.finlog.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/example/finlog/service/TransactionService.java
+++ b/src/main/java/org/example/finlog/service/TransactionService.java
@@ -1,13 +1,12 @@
 package org.example.finlog.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.example.finlog.DTO.TransactionRequest;
 import org.example.finlog.entity.Transaction;
 import org.example.finlog.entity.User;
 import org.example.finlog.enums.Category;
+import org.example.finlog.exception.NotFoundException;
 import org.example.finlog.repository.TransactionRepository;
 import org.example.finlog.util.UuidGenerator;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.AccessDeniedException;
@@ -31,7 +30,7 @@ public class TransactionService {
 
     public List<Transaction> getFilteredData(String username, Category category, LocalDateTime startDate, LocalDateTime endDate) {
         User user = userService.getUserByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+                .orElseThrow(() -> new NotFoundException("User not found: " + username));
 
         UUID userId = user.getId();
         LocalDateTime registrationDate = userService.getRegistrationDate(userId);
@@ -49,7 +48,7 @@ public class TransactionService {
 
     public void save(String username, TransactionRequest request) {
         User user = userService.getUserByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+                .orElseThrow(() -> new NotFoundException("User not found: " + username));
 
         if (request.getId() == null) {
             request.setId(uuidGenerator.generate());
@@ -61,10 +60,10 @@ public class TransactionService {
 
     public void update(String username, TransactionRequest request) throws AccessDeniedException {
         User user = userService.getUserByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+                .orElseThrow(() -> new NotFoundException("User not found: " + username));
 
         Transaction existing = Optional.ofNullable(transactionRepository.getById(request.getId()))
-                .orElseThrow(() -> new EntityNotFoundException("Transaction not found"));
+                .orElseThrow(() -> new NotFoundException("Transaction not found"));
 
         checkOwnership(user, existing);
         Transaction transaction = mapToEntity(request, user);
@@ -73,10 +72,10 @@ public class TransactionService {
 
     public void delete(String username, UUID id) throws AccessDeniedException {
         User user = userService.getUserByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+                .orElseThrow(() -> new NotFoundException("User not found: " + username));
 
         Transaction existing = Optional.ofNullable(transactionRepository.getById(id))
-                .orElseThrow(() -> new EntityNotFoundException("Transaction not found"));
+                .orElseThrow(() -> new NotFoundException("Transaction not found"));
 
         checkOwnership(user, existing);
         transactionRepository.delete(id);

--- a/src/test/java/org/example/finlog/unit/service/TransactionServiceTest.java
+++ b/src/test/java/org/example/finlog/unit/service/TransactionServiceTest.java
@@ -1,11 +1,11 @@
 package org.example.finlog.unit.service;
 
 
-import jakarta.persistence.EntityNotFoundException;
 import org.example.finlog.DTO.TransactionRequest;
 import org.example.finlog.entity.Transaction;
 import org.example.finlog.entity.User;
 import org.example.finlog.enums.Category;
+import org.example.finlog.exception.NotFoundException;
 import org.example.finlog.repository.TransactionRepository;
 import org.example.finlog.service.TransactionService;
 import org.example.finlog.service.UserService;
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.math.BigDecimal;
 import java.nio.file.AccessDeniedException;
@@ -109,7 +108,7 @@ class TransactionServiceTest {
 
         assertThatThrownBy(() ->
                 transactionService.getFilteredData("nope@example.com", null, null, null)
-        ).isInstanceOf(UsernameNotFoundException.class)
+        ).isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("User not found");
     }
 
@@ -236,7 +235,7 @@ class TransactionServiceTest {
 
         assertThatThrownBy(() ->
                 transactionService.update(user.getEmail(), request)
-        ).isInstanceOf(EntityNotFoundException.class)
+        ).isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("Transaction not found");
 
         verify(transactionRepository, never()).update(any());
@@ -251,7 +250,7 @@ class TransactionServiceTest {
 
         assertThatThrownBy(() ->
                 transactionService.update(user.getEmail(), request)
-        ).isInstanceOf(UsernameNotFoundException.class)
+        ).isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("User not found: " + user.getEmail());
     }
 
@@ -314,7 +313,7 @@ class TransactionServiceTest {
 
         assertThatThrownBy(() ->
                 transactionService.delete(user.getEmail(), txId)
-        ).isInstanceOf(EntityNotFoundException.class)
+        ).isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("Transaction not found");
     }
 
@@ -326,7 +325,7 @@ class TransactionServiceTest {
 
         assertThatThrownBy(() ->
                 transactionService.delete(user.getEmail(), txId)
-        ).isInstanceOf(UsernameNotFoundException.class)
+        ).isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("User not found: " + user.getEmail());
     }
 }


### PR DESCRIPTION
## Changes Introduced
**1. Error handling**
- Removed try-catch blocks from controller
- Implemented unified exception handling in `GlobalExceptionHandler`:
    - `NotFoundException` -> 404 Not Found
    - `AccessDeniedException` -> 403 Forbidden
    - `BadCredentialsException` -> 400 Bad Request
    - Validation errors -> 400 Bad Request


**2. Logging**
- Added logging in:
    - `AuthController`
    - `TransactionController` 
    - `GlobalExceptionHandler`
 

**3. API Changes**
- All error responses now following consistent format: 
```json
{
    "message": "error message"
}
```