### PR TITLE
refactor: add base repository and query factory

### DIFF
--- a/src/main/java/org/example/finlog/entity/BaseEntity.java
+++ b/src/main/java/org/example/finlog/entity/BaseEntity.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @MappedSuperclass
 @AllArgsConstructor
 @NoArgsConstructor
-public class FinlogEntity {
+public class BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/org/example/finlog/entity/Transaction.java
+++ b/src/main/java/org/example/finlog/entity/Transaction.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = TableName.TRANSACTION)
-public class Transaction extends FinlogEntity{
+public class Transaction extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(

--- a/src/main/java/org/example/finlog/entity/User.java
+++ b/src/main/java/org/example/finlog/entity/User.java
@@ -22,7 +22,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = TableName.USER)
-public class User extends FinlogEntity {
+public class User extends BaseEntity {
 
     @Column(unique = true, nullable = false)
     private String email;

--- a/src/main/java/org/example/finlog/factory/common/query/BaseQueryFactory.java
+++ b/src/main/java/org/example/finlog/factory/common/query/BaseQueryFactory.java
@@ -2,18 +2,19 @@ package org.example.finlog.factory.common.query;
 
 import org.example.finlog.query_builder.builder.InsertQueryBuilder;
 import org.example.finlog.query_builder.builder.SelectQueryBuilder;
+import org.example.finlog.query_builder.builder.UpdateQueryBuilder;
 
+import java.util.Arrays;
 import java.util.UUID;
+import java.util.function.IntFunction;
+import java.util.stream.Stream;
+
+import static org.example.finlog.query_builder.util.RawExpression.raw;
 
 public abstract class BaseQueryFactory {
 
-    public static String save(String table, String[] fields, Object[] values) {
-        return InsertQueryBuilder.builder()
-                .insertInto(table)
-                .fields(fields)
-                .values(values)
-                .build();
-    }
+
+//    *** SELECT SECTION ***
 
     public static String getByField(String table, String field, Object value) {
         return SelectQueryBuilder.builder()
@@ -31,5 +32,57 @@ public abstract class BaseQueryFactory {
                 .where("id").eq(id)
                 .and("deleted").eq(false)
                 .build();
+    }
+
+
+//    *** INSERT SECTION ***
+
+    public static String save(String table, String[] fields, Object[] values) {
+        return InsertQueryBuilder.builder()
+                .insertInto(table)
+                .fields(fields)
+                .values(values)
+                .build();
+    }
+
+
+//    *** UPDATE SECTION ***
+
+    public static String delete(String table, UUID id, Long version) {
+        String[] fields = {"deleted", "deleted_at", "version"};
+        Object[] values = {
+                true,
+                raw("NOW()"),
+                raw("version + 1")
+        };
+        return buildUpdate(table, id, version, fields, values);
+    }
+
+    public static String update(String table, UUID id, Long version, String[] fields, Object[] values) {
+        String[] metadataFields = {"version", "updated_at"};
+        Object[] metadataValues = {raw("version + 1"), raw("NOW()")};
+
+        String[] fieldsWithMetadata = combine(fields, metadataFields, String[]::new);
+        Object[] valuesWithMetadata = combine(values, metadataValues, Object[]::new);
+
+        return buildUpdate(table, id, version, fieldsWithMetadata, valuesWithMetadata);
+    }
+
+    private static String buildUpdate(String table, UUID id, Long version, String[] fields, Object[] values) {
+        return UpdateQueryBuilder.builder()
+                .update(table)
+                .set(fields)
+                .values(values)
+                .where("id").eq(id)
+                .and("deleted").eq(false)
+                .and("version").eq(version)
+                .build();
+    }
+
+    private static <T> T[] combine(T[] arr1, T[] arr2, IntFunction<T[]> generator) {
+        return Stream.concat(
+                Arrays.stream(arr1),
+                Arrays.stream(arr2)
+        ).toArray(generator);
     }
 }

--- a/src/main/java/org/example/finlog/factory/common/query/BaseQueryFactory.java
+++ b/src/main/java/org/example/finlog/factory/common/query/BaseQueryFactory.java
@@ -1,0 +1,35 @@
+package org.example.finlog.factory.common.query;
+
+import org.example.finlog.query_builder.builder.InsertQueryBuilder;
+import org.example.finlog.query_builder.builder.SelectQueryBuilder;
+
+import java.util.UUID;
+
+public abstract class BaseQueryFactory {
+
+    protected static String save(String table, String[] fields, Object[] values) {
+        return InsertQueryBuilder.builder()
+                .insertInto(table)
+                .fields(fields)
+                .values(values)
+                .build();
+    }
+
+    protected static String getByField(String table, String field, Object value) {
+        return SelectQueryBuilder.builder()
+                .select()
+                .from(table)
+                .where(field).eq(value)
+                .and("deleted").eq(false)
+                .build();
+    }
+
+    protected static String getSingleField(String table, String field, UUID id) {
+        return SelectQueryBuilder.builder()
+                .select(field)
+                .from(table)
+                .where("id").eq(id)
+                .and("deleted").eq(false)
+                .build();
+    }
+}

--- a/src/main/java/org/example/finlog/factory/common/query/BaseQueryFactory.java
+++ b/src/main/java/org/example/finlog/factory/common/query/BaseQueryFactory.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public abstract class BaseQueryFactory {
 
-    protected static String save(String table, String[] fields, Object[] values) {
+    public static String save(String table, String[] fields, Object[] values) {
         return InsertQueryBuilder.builder()
                 .insertInto(table)
                 .fields(fields)
@@ -15,7 +15,7 @@ public abstract class BaseQueryFactory {
                 .build();
     }
 
-    protected static String getByField(String table, String field, Object value) {
+    public static String getByField(String table, String field, Object value) {
         return SelectQueryBuilder.builder()
                 .select()
                 .from(table)
@@ -24,7 +24,7 @@ public abstract class BaseQueryFactory {
                 .build();
     }
 
-    protected static String getSingleField(String table, String field, UUID id) {
+    public static String getSingleField(String table, String field, UUID id) {
         return SelectQueryBuilder.builder()
                 .select(field)
                 .from(table)

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionDeleteFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionDeleteFactory.java
@@ -1,26 +1,11 @@
 package org.example.finlog.factory.transaction.query;
 
-import org.example.finlog.query_builder.builder.UpdateQueryBuilder;
-
 import java.util.UUID;
-
-import static org.example.finlog.query_builder.util.RawExpression.raw;
 
 public class TransactionDeleteFactory extends TransactionQueryFactory {
 
     public static String delete(UUID id, Long version) {
-        return UpdateQueryBuilder.builder()
-                .update(TABLE)
-                .set("deleted", "deleted_at", "version")
-                .values(
-                        true,
-                        raw("NOW()"),
-                        raw("version + 1")
-                )
-                .where("id").eq(id)
-                .and("deleted").eq(false)
-                .and("version").eq(version)
-                .build();
+        return delete(TABLE, id, version);
     }
 }
 

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionInsertFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionInsertFactory.java
@@ -6,7 +6,7 @@ import org.example.finlog.query_builder.builder.InsertQueryBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TransactionInsertFactory extends TransactionQueryFactory{
+public class TransactionInsertFactory extends TransactionQueryFactory {
 
     public static String save(Transaction transaction) {
         List<String> fields = new ArrayList<>(List.of(
@@ -26,10 +26,10 @@ public class TransactionInsertFactory extends TransactionQueryFactory{
             values.add(transaction.getTransactionDate());
         }
 
-        return InsertQueryBuilder.builder()
-                .insertInto(TABLE)
-                .fields(fields.toArray(new String[0]))
-                .values(values.toArray())
-                .build();
+        return save(
+                TABLE,
+                fields.toArray(new String[0]),
+                values.toArray()
+        );
     }
 }

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionInsertFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionInsertFactory.java
@@ -1,7 +1,6 @@
 package org.example.finlog.factory.transaction.query;
 
 import org.example.finlog.entity.Transaction;
-import org.example.finlog.query_builder.builder.InsertQueryBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +27,7 @@ public class TransactionInsertFactory extends TransactionQueryFactory {
 
         return save(
                 TABLE,
-                fields.toArray(new String[0]),
+                fields.toArray(String[]::new),
                 values.toArray()
         );
     }

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionQueryFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionQueryFactory.java
@@ -1,7 +1,8 @@
 package org.example.finlog.factory.transaction.query;
 
+import org.example.finlog.factory.common.query.BaseQueryFactory;
 import org.example.finlog.util.TableName;
 
-public abstract class TransactionQueryFactory {
+public abstract class TransactionQueryFactory extends BaseQueryFactory {
     protected static final String TABLE = TableName.TRANSACTION;
 }

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionSelectFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionSelectFactory.java
@@ -27,10 +27,6 @@ public class TransactionSelectFactory extends TransactionQueryFactory{
         return query.orderBy("transaction_date").build();
     }
 
-    public static String getById(UUID id) {
-        return getByField(TABLE, "id", id);
-    }
-
     public static String getAllByUserId(UUID userId) {
         return SelectQueryBuilder.builder()
                 .select()

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionSelectFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionSelectFactory.java
@@ -28,12 +28,7 @@ public class TransactionSelectFactory extends TransactionQueryFactory{
     }
 
     public static String getById(UUID id) {
-        return SelectQueryBuilder.builder()
-                .select()
-                .from(TABLE)
-                .where("id").eq(id)
-                .and("deleted").eq(false)
-                .build();
+        return getByField(TABLE, "id", id);
     }
 
     public static String getAllByUserId(UUID userId) {

--- a/src/main/java/org/example/finlog/factory/transaction/query/TransactionUpdateFactory.java
+++ b/src/main/java/org/example/finlog/factory/transaction/query/TransactionUpdateFactory.java
@@ -1,25 +1,20 @@
 package org.example.finlog.factory.transaction.query;
 
 import org.example.finlog.entity.Transaction;
-import org.example.finlog.query_builder.builder.UpdateQueryBuilder;
 
-import static org.example.finlog.query_builder.util.RawExpression.raw;
-
-public class TransactionUpdateFactory extends TransactionQueryFactory{
+public class TransactionUpdateFactory extends TransactionQueryFactory {
 
     public static String update(Transaction transaction) {
-        return UpdateQueryBuilder.builder()
-                .update(TABLE)
-                .set("amount", "description", "category", "version", "updated_at")
-                .values(
+        return update(
+                TABLE,
+                transaction.getId(),
+                transaction.getVersion(),
+                new String[]{"amount", "description", "category"},
+                new Object[]{
                         transaction.getAmount(),
                         transaction.getDescription(),
-                        transaction.getCategory().toString(),
-                        raw("version + 1"),
-                        raw("NOW()")
-                )
-                .where("id").eq(transaction.getId())
-                .and("version").eq(transaction.getVersion())
-                .build();
+                        transaction.getCategory().toString()
+                }
+        );
     }
 }

--- a/src/main/java/org/example/finlog/factory/user/query/UserInsertFactory.java
+++ b/src/main/java/org/example/finlog/factory/user/query/UserInsertFactory.java
@@ -1,9 +1,6 @@
 package org.example.finlog.factory.user.query;
 
 import org.example.finlog.entity.User;
-import org.example.finlog.factory.common.query.BaseQueryFactory;
-import org.example.finlog.query_builder.builder.InsertQueryBuilder;
-import org.example.finlog.util.TableName;
 
 public class UserInsertFactory extends UserQueryFactory {
     public static String save(User user) {

--- a/src/main/java/org/example/finlog/factory/user/query/UserInsertFactory.java
+++ b/src/main/java/org/example/finlog/factory/user/query/UserInsertFactory.java
@@ -1,21 +1,20 @@
 package org.example.finlog.factory.user.query;
 
 import org.example.finlog.entity.User;
+import org.example.finlog.factory.common.query.BaseQueryFactory;
 import org.example.finlog.query_builder.builder.InsertQueryBuilder;
+import org.example.finlog.util.TableName;
 
 public class UserInsertFactory extends UserQueryFactory {
-
     public static String save(User user) {
-        return InsertQueryBuilder.builder()
-                .insertInto(TABLE)
-                .fields("id", "name", "email", "password_hash", "registration_date")
-                .values(
-                        user.getId(),
-                        user.getName(),
-                        user.getEmail(),
-                        user.getPasswordHash(),
-                        user.getRegistrationDate()
-                )
-                .build();
+        String[] fields = {"id", "name", "email", "password_hash", "registration_date"};
+        Object[] values = {
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getPasswordHash(),
+                user.getRegistrationDate()
+        };
+        return save(TABLE, fields, values);
     }
 }

--- a/src/main/java/org/example/finlog/factory/user/query/UserQueryFactory.java
+++ b/src/main/java/org/example/finlog/factory/user/query/UserQueryFactory.java
@@ -1,7 +1,8 @@
 package org.example.finlog.factory.user.query;
 
+import org.example.finlog.factory.common.query.BaseQueryFactory;
 import org.example.finlog.util.TableName;
 
-public abstract class UserQueryFactory {
+public abstract class UserQueryFactory extends BaseQueryFactory {
     protected final static String TABLE = TableName.USER;
 }

--- a/src/main/java/org/example/finlog/factory/user/query/UserSelectFactory.java
+++ b/src/main/java/org/example/finlog/factory/user/query/UserSelectFactory.java
@@ -1,26 +1,14 @@
 package org.example.finlog.factory.user.query;
 
-import org.example.finlog.query_builder.builder.SelectQueryBuilder;
-
 import java.util.UUID;
 
 public class UserSelectFactory extends UserQueryFactory {
 
     public static String getByEmail(String email) {
-        return SelectQueryBuilder.builder()
-                .select()
-                .from(TABLE)
-                .where("email").eq(email)
-                .and("deleted").eq(false)
-                .build();
+        return getByField(TABLE, "email", email);
     }
 
     public static String getSingleField(String field, UUID id) {
-        return SelectQueryBuilder.builder()
-                .select(field)
-                .from(TABLE)
-                .where("id").eq(id)
-                .and("deleted").eq(false)
-                .build();
+        return getSingleField(TABLE, field, id);
     }
 }

--- a/src/main/java/org/example/finlog/repository/BaseRepository.java
+++ b/src/main/java/org/example/finlog/repository/BaseRepository.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public abstract class BaseRepository<T extends BaseEntity> {
     protected final String table;
-    protected final Class<T> entityClass;
     protected final JdbcTemplate jdbcTemplate;
     protected final RowMapper<T> rowMapper;
 

--- a/src/main/java/org/example/finlog/repository/BaseRepository.java
+++ b/src/main/java/org/example/finlog/repository/BaseRepository.java
@@ -1,0 +1,32 @@
+package org.example.finlog.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.example.finlog.entity.BaseEntity;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public abstract class BaseRepository<T extends BaseEntity> {
+    protected final String table;
+    protected final Class<T> entityClass;
+    protected final JdbcTemplate jdbcTemplate;
+    protected final RowMapper<T> rowMapper;
+
+    protected void checkOptimisticLock(int affectedRows, UUID id, String message) {
+        if (affectedRows == 0 && existsById(id)) {
+            throw new OptimisticLockingFailureException(message);
+        }
+    }
+
+    protected boolean existsById(UUID id) {
+        return Boolean.TRUE.equals(
+                jdbcTemplate.queryForObject(
+                        "select exists(select 1 from " + table + " where id = ?)",
+                        Boolean.class,
+                        id
+                ));
+    }
+}

--- a/src/main/java/org/example/finlog/repository/BaseRepository.java
+++ b/src/main/java/org/example/finlog/repository/BaseRepository.java
@@ -2,6 +2,8 @@ package org.example.finlog.repository;
 
 import lombok.RequiredArgsConstructor;
 import org.example.finlog.entity.BaseEntity;
+import org.example.finlog.factory.common.query.BaseQueryFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -14,6 +16,17 @@ public abstract class BaseRepository<T extends BaseEntity> {
     protected final Class<T> entityClass;
     protected final JdbcTemplate jdbcTemplate;
     protected final RowMapper<T> rowMapper;
+
+    public abstract void save(T entity);
+
+    public T getById(UUID id) {
+        try {
+            String query = BaseQueryFactory.getByField(table, "id", id);
+            return jdbcTemplate.queryForObject(query, rowMapper);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
 
     protected void checkOptimisticLock(int affectedRows, UUID id, String message) {
         if (affectedRows == 0 && existsById(id)) {

--- a/src/main/java/org/example/finlog/repository/TransactionRepository.java
+++ b/src/main/java/org/example/finlog/repository/TransactionRepository.java
@@ -6,11 +6,10 @@ import org.example.finlog.factory.transaction.query.TransactionDeleteFactory;
 import org.example.finlog.factory.transaction.query.TransactionInsertFactory;
 import org.example.finlog.factory.transaction.query.TransactionSelectFactory;
 import org.example.finlog.factory.transaction.query.TransactionUpdateFactory;
+import org.example.finlog.util.TableName;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,13 +18,14 @@ import java.util.List;
 import java.util.UUID;
 
 @Repository
-public class TransactionRepository {
-    private final JdbcTemplate jdbcTemplate;
-    private final RowMapper<Transaction> rowMapper =
-            new BeanPropertyRowMapper<>(Transaction.class);
-
+public class TransactionRepository extends BaseRepository<Transaction> {
     public TransactionRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
+        super(
+                TableName.TRANSACTION,
+                Transaction.class,
+                jdbcTemplate,
+                new BeanPropertyRowMapper<>(Transaction.class)
+        );
     }
 
     @Transactional
@@ -58,12 +58,11 @@ public class TransactionRepository {
         String query = TransactionDeleteFactory.delete(id, version);
         int affectedRows = jdbcTemplate.update(query);
 
-        if (affectedRows == 0 && existsById(id)) {
-            throw new OptimisticLockingFailureException(
-                    "Failed to delete transaction " + id
-                    + " with version " + version
-            );
-        }
+        checkOptimisticLock(
+                affectedRows, id,
+                "Failed to delete transaction " + id
+                + " with version " + version
+        );
     }
 
     @Transactional
@@ -71,12 +70,12 @@ public class TransactionRepository {
         String query = TransactionUpdateFactory.update(transaction);
         int affectedRows = jdbcTemplate.update(query);
 
-        if (affectedRows == 0 && existsById(transaction.getId())) {
-            throw new OptimisticLockingFailureException(
-                    "Failed to update transaction " + transaction.getId()
-                    + "with version " + transaction.getVersion()
-            );
-        }
+        checkOptimisticLock(
+                affectedRows,
+                transaction.getId(),
+                "Failed to update transaction " + transaction.getId()
+                + " with version " + transaction.getVersion()
+        );
     }
 
     @Transactional
@@ -87,14 +86,5 @@ public class TransactionRepository {
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
-    }
-
-    private boolean existsById(UUID id) {
-        return Boolean.TRUE.equals(
-                jdbcTemplate.queryForObject(
-                        "select exists(select 1 from transaction_ where id = ?)",
-                        Boolean.class,
-                        id
-                ));
     }
 }

--- a/src/main/java/org/example/finlog/repository/TransactionRepository.java
+++ b/src/main/java/org/example/finlog/repository/TransactionRepository.java
@@ -21,7 +21,6 @@ public class TransactionRepository extends BaseRepository<Transaction> {
     public TransactionRepository(JdbcTemplate jdbcTemplate) {
         super(
                 TableName.TRANSACTION,
-                Transaction.class,
                 jdbcTemplate,
                 new BeanPropertyRowMapper<>(Transaction.class)
         );

--- a/src/main/java/org/example/finlog/repository/TransactionRepository.java
+++ b/src/main/java/org/example/finlog/repository/TransactionRepository.java
@@ -7,7 +7,6 @@ import org.example.finlog.factory.transaction.query.TransactionInsertFactory;
 import org.example.finlog.factory.transaction.query.TransactionSelectFactory;
 import org.example.finlog.factory.transaction.query.TransactionUpdateFactory;
 import org.example.finlog.util.TableName;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -76,15 +75,5 @@ public class TransactionRepository extends BaseRepository<Transaction> {
                 "Failed to update transaction " + transaction.getId()
                 + " with version " + transaction.getVersion()
         );
-    }
-
-    @Transactional
-    public Transaction getById(UUID id) {
-        try {
-            String query = TransactionSelectFactory.getById(id);
-            return jdbcTemplate.queryForObject(query, rowMapper);
-        } catch (EmptyResultDataAccessException e) {
-            return null;
-        }
     }
 }

--- a/src/main/java/org/example/finlog/repository/UserRepository.java
+++ b/src/main/java/org/example/finlog/repository/UserRepository.java
@@ -18,7 +18,6 @@ public class UserRepository extends BaseRepository<User>{
         public UserRepository(JdbcTemplate jdbcTemplate) {
         super(
                 TableName.USER,
-                User.class,
                 jdbcTemplate,
                 new BeanPropertyRowMapper<>(User.class)
         );

--- a/src/main/java/org/example/finlog/repository/UserRepository.java
+++ b/src/main/java/org/example/finlog/repository/UserRepository.java
@@ -2,12 +2,11 @@ package org.example.finlog.repository;
 
 import org.example.finlog.entity.User;
 import org.example.finlog.factory.user.query.UserInsertFactory;
-import org.example.finlog.factory.user.query.UserQueryFactory;
 import org.example.finlog.factory.user.query.UserSelectFactory;
+import org.example.finlog.util.TableName;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,13 +14,14 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Repository
-public class UserRepository {
-    private final JdbcTemplate jdbcTemplate;
-    private final RowMapper<User> rowMapper =
-            new BeanPropertyRowMapper<>(User.class);
-
-    public UserRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
+public class UserRepository extends BaseRepository<User>{
+        public UserRepository(JdbcTemplate jdbcTemplate) {
+        super(
+                TableName.USER,
+                User.class,
+                jdbcTemplate,
+                new BeanPropertyRowMapper<>(User.class)
+        );
     }
 
     @Transactional

--- a/src/test/java/org/example/finlog/integration/repository/TransactionRepositoryTest.java
+++ b/src/test/java/org/example/finlog/integration/repository/TransactionRepositoryTest.java
@@ -220,7 +220,7 @@ class TransactionRepositoryTest {
         ).isInstanceOf(OptimisticLockingFailureException.class)
                 .hasMessageContaining(
                         "Failed to update transaction " + transaction.getId()
-                                + "with version " + transaction.getVersion()
+                                + " with version " + transaction.getVersion()
                 );
     }
 


### PR DESCRIPTION
## Changes Introduced
- Implemented `BaseRepository` and `BaseQueryFactory` contains common methods and fields
- Updated repositories and query factories to work with base classes
- Renamed `FinlogEntity` to `BaseEntity` to keep naming style consistency